### PR TITLE
Prevent knex from doing migrations on startup

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3,20 +3,10 @@ const log = require('loglevel');
 // setup log level
 require('./setup');
 const app = require('./app');
-const knex = require('../database/connection');
 
 const PORT = process.env.NODE_PORT || 3006;
 
-knex.migrate
-  .latest()
-  .then((migrations) => {
-    log.info('migrations', migrations);
-    app.listen(PORT, () => {
-      log.info(`Listening on Port ${PORT}!`);
-      log.debug('debug log level!');
-    });
-  })
-  .catch((error) => {
-    log.error(error);
-    knex.destroy();
-  });
+app.listen(PORT, () => {
+  log.info(`listening on port:${PORT}`);
+  log.debug('debug log level!');
+});


### PR DESCRIPTION
A bit of script that auto-ran migrations was left on the server.js file and caused error on startup