### PR TITLE
fix: refactor sql for get stakeholders request

### DIFF
--- a/server/models/Stakeholder.spec.js
+++ b/server/models/Stakeholder.spec.js
@@ -25,29 +25,19 @@ describe('Stakeholder Model', () => {
 
   describe('getAllStakeholders', () => {
     let getFilterStub;
-    let getParentsStub;
-    let getChildrenStub;
     before(() => {
       getFilterStub = sinon
-        .stub(StakeholderRepository.prototype, 'getFilter')
+        .stub(StakeholderRepository.prototype, 'getByFilter')
         .callsFake(async (filter) => {
           return {
             count: 1,
             stakeholders: [{ id: filter.id }],
           };
         });
-      getParentsStub = sinon
-        .stub(StakeholderRepository.prototype, 'getParents')
-        .resolves([]);
-      getChildrenStub = sinon
-        .stub(StakeholderRepository.prototype, 'getChildren')
-        .resolves([]);
     });
 
     after(() => {
       getFilterStub.restore();
-      getParentsStub.restore();
-      getChildrenStub.restore();
     });
 
     it('should get stakeholders with filter -- id (uuid)', async () => {

--- a/server/repositories/StakeholderRepository.spec.js
+++ b/server/repositories/StakeholderRepository.spec.js
@@ -21,45 +21,6 @@ describe('StakeholderRepository', () => {
     mockKnex.unmock(knex);
   });
 
-  it('getStakeholderTreeById', async () => {
-    tracker.uninstall();
-    tracker.install();
-    tracker.on('query', (query, step) => {
-      const stakeholder = { id: 1 };
-      const count = { count: 1 };
-      [
-        function firstQuery() {
-          const bool = query.sql.match(/select.*.*id.*/);
-          expect(bool);
-          query.response(stakeholder);
-        },
-        function firstQuery() {
-          const bool = query.sql.match(/select.*.*id.*/);
-          expect(bool);
-          query.response([]);
-        },
-        function firstQuery() {
-          const bool = query.sql.match(/select.*.*id.*/);
-          expect(bool);
-          query.response([]);
-        },
-        function secondQuery() {
-          const bool = query.sql.match(/count.*.*id.*/);
-          expect(bool);
-          query.response([count]);
-        },
-        function finalQuery() {
-          query.response({ stakeholders: [stakeholder], count });
-        },
-      ][step - 1]();
-    });
-
-    const { stakeholders, count } =
-      await stakeholderRepository.getStakeholderTreeById(1);
-    expect(stakeholders[0]).property('id').eq(1);
-    expect(count).eq(1);
-  });
-
   it('getStakeholderByOrganizationId', async () => {
     tracker.uninstall();
     tracker.install();

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -33,7 +33,7 @@ exports.handlerWrapper = (fn) =>
   };
 
 exports.errorHandler = (err, req, res, _next) => {
-  log.debug('errorHandler error:', err);
+  log.error('errorHandler error:', err);
   if (err instanceof HttpError) {
     res.status(err.code).send({
       code: err.code,


### PR DESCRIPTION
Hello @gwynndp, I had to refactor the SQL for the getStakeholders as the previous implementation was acquiring a new connection to the db per row hence maxing out the simultaneous connections. Kindly help review the updates.